### PR TITLE
py: Fix list repr on recursive element situation.

### DIFF
--- a/py/list.go
+++ b/py/list.go
@@ -2,6 +2,10 @@
 
 package py
 
+import (
+	"bytes"
+)
+
 var ListType = ObjectType.NewType("list", "list() -> new empty list\nlist(iterable) -> new list initialized from iterable's items", ListNew, nil)
 
 // FIXME lists are mutable so this should probably be struct { Tuple } then can use the sub methods on Tuple
@@ -97,7 +101,26 @@ func (l *List) M__str__() (Object, error) {
 }
 
 func (l *List) M__repr__() (Object, error) {
-	return Tuple(l.Items).repr("[", "]")
+	var out bytes.Buffer
+	out.WriteString("[")
+	for i, obj := range l.Items {
+		var str string
+		var err error
+		if i != 0 {
+			out.WriteString(", ")
+		}
+		if obj == l {
+			str = "[...]"
+		} else {
+			str, err = ReprAsString(obj)
+			if err != nil {
+				return nil, err
+			}
+		}
+		out.WriteString(str)
+	}
+	out.WriteString("]")
+	return String(out.String()), nil
 }
 
 func (l *List) M__len__() (Object, error) {

--- a/py/tests/list.py
+++ b/py/tests/list.py
@@ -9,5 +9,11 @@ assert repr([]) == "[]"
 assert repr([1,2,3]) == "[1, 2, 3]"
 assert repr([1,[2,3],4]) == "[1, [2, 3], 4]"
 assert repr(["1",[2.5,17,[]]]) == "['1', [2.5, 17, []]]"
+r = [1,2,3]
+r[0] = r
+assert repr(r) == "[[...], 2, 3]"
+r[2] = r
+assert repr(r) == "[[...], 2, [...]]"
+assert repr(r[0]) == "[[...], 2, [...]]"
 
 doc="finished"


### PR DESCRIPTION
I change the list repr not to use tuple repr, since current usage can't check an address of the parent element.

Fixes: #2 